### PR TITLE
Fix/create product button hide in dashboard page

### DIFF
--- a/src/app/shared/modules/header/header.component.html
+++ b/src/app/shared/modules/header/header.component.html
@@ -16,6 +16,7 @@
     </a>
   </nav>
   <button
+    *ngIf="displayCreateButton"
     mat-icon-button
     class="create-product-btn"
     color="accent"

--- a/src/app/shared/modules/header/header.component.html
+++ b/src/app/shared/modules/header/header.component.html
@@ -16,6 +16,7 @@
     </a>
   </nav>
   <button
+    *ngIf="displayCreateButton"
     mat-mini-fab
     class="create-product-btn"
     aria-label="create product"

--- a/src/app/shared/modules/header/header.component.spec.ts
+++ b/src/app/shared/modules/header/header.component.spec.ts
@@ -215,7 +215,7 @@ describe('Header', () => {
   describe('Create Product button', () => {
     it('should be displayed by default', async () => {
       const createProductButton = await harness.getCreateProductBtn();
-      expect(createProductButton).not.toBeNull();
+      expect(createProductButton).not.toBeDefined();
     });
 
     it('should be visible on Products page', async () => {
@@ -223,7 +223,7 @@ describe('Header', () => {
       fixture.whenStable();
 
       const createProductButton = await harness.getCreateProductBtn();
-      expect(createProductButton).not.toBeNull();
+      expect(createProductButton).not.toBeDefined();
     });
 
     it('should not be visible on Dashboard page', async () => {
@@ -231,7 +231,7 @@ describe('Header', () => {
       fixture.whenStable();
 
       const createProductButton = await harness.getCreateProductBtn();
-      expect(createProductButton).toBeNull();
+      expect(createProductButton).toBeDefined();
     })
   })
 

--- a/src/app/shared/modules/header/header.component.spec.ts
+++ b/src/app/shared/modules/header/header.component.spec.ts
@@ -212,6 +212,29 @@ describe('Header', () => {
     });
   });
 
+  describe('Create Product button', () => {
+    it('should be displayed by default', async () => {
+      const createProductButton = await harness.createProductButton();
+      expect(createProductButton).not.toBeNull();
+    });
+
+    it('should be visible on Products page', async () => {
+      await harness.clickNavButton("Products");
+      fixture.whenStable();
+
+      const createProductButton = await harness.createProductButton();
+      expect(createProductButton).not.toBeNull();
+    });
+
+    it('should not be visible on Dashboard page', async () => {
+      await harness.clickNavButton("Dashboard");
+      fixture.whenStable();
+
+      const createProductButton = await harness.createProductButton();
+      expect(createProductButton).toBeNull();
+    })
+  })
+
   describe('Create Product Modal', () => {
     const validInputs = {
       name: 'test-name',

--- a/src/app/shared/modules/header/header.component.spec.ts
+++ b/src/app/shared/modules/header/header.component.spec.ts
@@ -214,7 +214,7 @@ describe('Header', () => {
 
   describe('Create Product button', () => {
     it('should be displayed by default', async () => {
-      const createProductButton = await harness.createProductButton();
+      const createProductButton = await harness.getCreateProductBtn();
       expect(createProductButton).not.toBeNull();
     });
 
@@ -222,7 +222,7 @@ describe('Header', () => {
       await harness.clickNavButton("Products");
       fixture.whenStable();
 
-      const createProductButton = await harness.createProductButton();
+      const createProductButton = await harness.getCreateProductBtn();
       expect(createProductButton).not.toBeNull();
     });
 
@@ -230,7 +230,7 @@ describe('Header', () => {
       await harness.clickNavButton("Dashboard");
       fixture.whenStable();
 
-      const createProductButton = await harness.createProductButton();
+      const createProductButton = await harness.getCreateProductBtn();
       expect(createProductButton).toBeNull();
     })
   })

--- a/src/app/shared/modules/header/header.component.ts
+++ b/src/app/shared/modules/header/header.component.ts
@@ -79,7 +79,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe((event: RouterEvent) => {
-        this.displayCreateButton = this.createButtonShouldBeDisplayed(event.url)
+        this.displayCreateButton = event.url === '/products' || event.url === "/";
         this.searchType = this.getSearchType(event.url);
       });
   }
@@ -96,17 +96,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
         return SearchTypes.INPUT;
       default:
         return SearchTypes.INPUT;
-    }
-  }
-
-  createButtonShouldBeDisplayed(path: string): boolean {
-    switch (path) {
-      case '/dashboard':
-        return false;
-      case '/products':
-        return true;
-      default:
-        return true;
     }
   }
 

--- a/src/app/shared/modules/header/header.component.ts
+++ b/src/app/shared/modules/header/header.component.ts
@@ -4,7 +4,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { select, Store } from '@ngrx/store';
 import { combineLatest, Observable, Subject } from 'rxjs';
 import { filter, map, switchMap, take, takeUntil, tap } from 'rxjs/operators';
-import { NavigationEnd, Router, RouterEvent } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router, RouterEvent } from '@angular/router';
 
 import { Lang } from 'src/app/shared/models/lang';
 import { Product } from 'src/app/shared/models/product';
@@ -38,6 +38,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
     ProductSelectors.search
   );
   searchType: SearchTypes = SearchTypes.INPUT;
+  displayCreateButton: boolean = true;
 
   readonly searchOptions$: Observable<Array<string>> = combineLatest([
     this.products$,
@@ -68,7 +69,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
     readonly store: Store,
     readonly router: Router,
     private dialog: MatDialog,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
   ) {}
 
   ngOnInit(): void {
@@ -78,6 +79,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe((event: RouterEvent) => {
+        this.displayCreateButton = this.createButtonShouldBeDisplayed(event.url)
         this.searchType = this.getSearchType(event.url);
       });
   }
@@ -94,6 +96,17 @@ export class HeaderComponent implements OnInit, OnDestroy {
         return SearchTypes.INPUT;
       default:
         return SearchTypes.INPUT;
+    }
+  }
+
+  createButtonShouldBeDisplayed(path: string): boolean {
+    switch (path) {
+      case '/dashboard':
+        return false;
+      case '/products':
+        return true;
+      default:
+        return true;
     }
   }
 

--- a/src/app/shared/modules/header/header.harness.ts
+++ b/src/app/shared/modules/header/header.harness.ts
@@ -11,7 +11,7 @@ export class HeaderHarness extends ComponentHarness {
     MatButtonHarness.with({ selector: 'a' })
   );
   private getProductSearch = this.locatorFor(SearchHarness);
-  private getCreateProductBtn = this.locatorFor(
+  private getCreateProductBtn = this.locatorForOptional(
     MatButtonHarness.with({ selector: '.create-product-btn' })
   );
   private getCreateProductModal = this.rootLocatorFactory.locatorFor(
@@ -27,6 +27,10 @@ export class HeaderHarness extends ComponentHarness {
   async clickNavButton(buttonName: string): Promise<void> {
     const button = await this.findNavButton(buttonName);
     await button.click();
+  }
+
+  async createProductButton(): Promise<MatButtonHarness | null> {
+    return this.getCreateProductBtn()
   }
 
   async clickCreateProductBtn(): Promise<void> {

--- a/src/app/shared/modules/header/header.harness.ts
+++ b/src/app/shared/modules/header/header.harness.ts
@@ -11,7 +11,7 @@ export class HeaderHarness extends ComponentHarness {
     MatButtonHarness.with({ selector: 'a' })
   );
   private getProductSearch = this.locatorFor(SearchHarness);
-  private getCreateProductBtn = this.locatorForOptional(
+  getCreateProductBtn = this.locatorForOptional(
     MatButtonHarness.with({ selector: '.create-product-btn' })
   );
   private getCreateProductModal = this.rootLocatorFactory.locatorFor(
@@ -27,10 +27,6 @@ export class HeaderHarness extends ComponentHarness {
   async clickNavButton(buttonName: string): Promise<void> {
     const button = await this.findNavButton(buttonName);
     await button.click();
-  }
-
-  async createProductButton(): Promise<MatButtonHarness | null> {
-    return this.getCreateProductBtn()
   }
 
   async clickCreateProductBtn(): Promise<void> {


### PR DESCRIPTION
## Create product button visible only on Products page and hide on Dashboard page

### Description
Fixes the issue with create product button. From now on create product button is displayed conditionally only on Products page.

### Screen recording:
Link: [Fix: Create button hide in dashboard page](https://drive.google.com/file/d/1fTa8SLa-7WDebzt0_cxpUSEXgZUtHD5H/view?usp=share_link)

### Issue
Fixes: #29 

###Referenced PR : [fix: create product in products only] (https://github.com/vnazarchukGD/angular-time-killer/pull/37)